### PR TITLE
fix root Makefile getting ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 *.lv2
 *.make
 *.make-e
-Makefile
 object_script.*.Debug
 object_script.*.Release
 


### PR DESCRIPTION
i was including this dir in another git repo and I noticed that your main Makefile is getting ignored. you must have forcefully put it here

this fix ignores all Makefiles but the root one

EDIT: actually it looks like the rest of the makefiles are needed too so i deleted the entry