### PR TITLE
Use build system flags also for lv2_ttl_generator

### DIFF
--- a/libs/lv2-ttl-generator/GNUmakefile
+++ b/libs/lv2-ttl-generator/GNUmakefile
@@ -6,7 +6,7 @@ build: ../lv2_ttl_generator
 mingw: ../lv2_ttl_generator.exe
 
 ../lv2_ttl_generator: lv2_ttl_generator.cpp
-	$(CXX) lv2_ttl_generator.cpp -o ../lv2_ttl_generator -ldl
+	$(CXX) lv2_ttl_generator.cpp $(CXXFLAGS) $(LDFLAGS) -o ../lv2_ttl_generator -ldl
 
 ../lv2_ttl_generator.exe: lv2_ttl_generator.cpp
 	$(CXX) lv2_ttl_generator.cpp -o ../lv2_ttl_generator.exe -static


### PR DESCRIPTION
Short story: it fixes issues using crossbuild environments

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>