### PR TITLE
MOD TAL-reverb2: Remove normalization

### DIFF
--- a/mod-lv2-data/TAL-Reverb-2.lv2/TAL-Reverb-2.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/TAL-Reverb-2.ttl
@@ -7,7 +7,7 @@
 @prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
 @prefix unit: <http://lv2plug.in/ns/extensions/units#> .
 
-<urn:juce:TalReverb2>
+<http://moddevices.com/plugins/tal-reverb-2>
     a lv2:ReverbPlugin, lv2:Plugin ;
     lv2:requiredFeature <http://lv2plug.in/ns/ext/buf-size#boundedBlockLength> ,
                         <http://lv2plug.in/ns/ext/urid#map> ;

--- a/mod-lv2-data/TAL-Reverb-2.lv2/TAL-Reverb-2.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/TAL-Reverb-2.ttl
@@ -1,4 +1,5 @@
 @prefix atom: <http://lv2plug.in/ns/ext/atom#> .
+@prefix epp:  <http://lv2plug.in/ns/ext/port-props#> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
@@ -99,6 +100,7 @@
         lv2:default 257.0 ;
         lv2:minimum 100.0 ;
         lv2:maximum 10000.0 ;
+		lv2:portProperty epp:logarithmic;
         unit:unit unit:hz ;
     ] ,
     [
@@ -109,6 +111,7 @@
         lv2:default 3039.0 ;
         lv2:minimum 100.0 ;
         lv2:maximum 10000.0 ;
+		lv2:portProperty epp:logarithmic;
         unit:unit unit:hz ;
     ] ,
     [
@@ -119,6 +122,7 @@
         lv2:default 2237.0 ;
         lv2:minimum 100.0 ;
         lv2:maximum 10000.0 ;
+		lv2:portProperty epp:logarithmic;
         unit:unit unit:hz ;
     ] ,
     [
@@ -156,7 +160,7 @@
         lv2:index 15 ;
         lv2:symbol "stereoWidth" ;
         lv2:name "stereo width" ;
-        lv2:default 1.000000 ;
+        lv2:default 1.0 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;
     ] ,
@@ -165,7 +169,7 @@
         lv2:index 16 ;
         lv2:symbol "stereo_input" ;
         lv2:name "stereo input" ;
-        lv2:default 0.000000 ;
+        lv2:default 0.0 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;
         lv2:portProperty lv2:toggled ;

--- a/mod-lv2-data/TAL-Reverb-2.lv2/TAL-Reverb-2.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/TAL-Reverb-2.ttl
@@ -4,7 +4,7 @@
 @prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
-@prefix units: <http://lv2plug.in/ns/extensions/units#> .
+@prefix unit: <http://lv2plug.in/ns/extensions/units#> .
 
 <urn:juce:TalReverb2>
     a lv2:ReverbPlugin, lv2:Plugin ;
@@ -13,9 +13,6 @@
     lv2:extensionData <http://lv2plug.in/ns/ext/options#interface> ,
                       <http://lv2plug.in/ns/ext/state#interface> ,
                       <http://kxstudio.sf.net/ns/lv2ext/programs#Interface> ;
-
-    ui:ui <urn:juce:TalReverb2#ExternalUI> ,
-          <urn:juce:TalReverb2#ParentUI> ;
 
     lv2:port [
         a lv2:InputPort, lv2:ControlPort ;
@@ -58,35 +55,26 @@
     lv2:port [
         a lv2:InputPort, lv2:ControlPort ;
         lv2:index 5 ;
-        lv2:symbol "unused" ;
-        lv2:name "unused" ;
-        lv2:default 0.000000 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 1.0 ;
-    ] ,
-    [
-        a lv2:InputPort, lv2:ControlPort ;
-        lv2:index 6 ;
         lv2:symbol "dry" ;
         lv2:name "dry" ;
         lv2:default 0.0 ;
         lv2:minimum -96.0 ;
         lv2:maximum 26.4 ;
-        units:unit units:db ;
+        unit:unit unit:db ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
-        lv2:index 7 ;
+        lv2:index 6 ;
         lv2:symbol "wet" ;
         lv2:name "wet" ;
         lv2:default -24.1 ;
         lv2:minimum -96.0 ;
         lv2:maximum 26.4 ;
-        units:unit units:db ;
+        unit:unit unit:db ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
-        lv2:index 8 ;
+        lv2:index 7 ;
         lv2:symbol "room_size" ;
         lv2:name "room size" ;
         lv2:default 0.752000 ;
@@ -95,91 +83,92 @@
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
-        lv2:index 9 ;
+        lv2:index 8 ;
         lv2:symbol "pre_delay" ;
         lv2:name "pre delay" ;
         lv2:default 37.0 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1000.0 ;
-        units:unit units:ms ;
+        unit:unit unit:ms ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 9 ;
+        lv2:symbol "low_shelf_frequency" ;
+        lv2:name "low frequency" ;
+        lv2:default 257.0 ;
+        lv2:minimum 100.0 ;
+        lv2:maximum 10000.0 ;
+        unit:unit unit:hz ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
         lv2:index 10 ;
-        lv2:symbol "low_shelf_frequency" ;
-        lv2:name "low shelf frequency" ;
-        lv2:default 257.0 ;
-        lv2:minimum 0.0 ;
+        lv2:symbol "high_shelf_frequency" ;
+        lv2:name "high frequency" ;
+        lv2:default 3039.0 ;
+        lv2:minimum 100.0 ;
         lv2:maximum 10000.0 ;
-        units:unit units:hz ;
+        unit:unit unit:hz ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
         lv2:index 11 ;
-        lv2:symbol "high_shelf_frequency" ;
-        lv2:name "high shelf frequency" ;
-        lv2:default 3039.0 ;
-        lv2:minimum 0.0 ;
+        lv2:symbol "peak_frequency" ;
+        lv2:name "mid frequency" ;
+        lv2:default 2237.0 ;
+        lv2:minimum 100.0 ;
         lv2:maximum 10000.0 ;
-        units:unit units:hz ;
+        unit:unit unit:hz ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
         lv2:index 12 ;
-        lv2:symbol "peak_frequency" ;
-        lv2:name "mid frequency" ;
-        lv2:default 2237.0 ;
-        lv2:minimum 0.0 ;
-        lv2:maximum 10000.0 ;
-        units:unit units:hz ;
+        lv2:symbol "low_shelf_gain" ;
+        lv2:name "low gain" ;
+        lv2:default -0.4 ;
+        lv2:minimum -18.0 ;
+        lv2:maximum 0.0 ;
+        unit:unit unit:db ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
         lv2:index 13 ;
-        lv2:symbol "low_shelf_gain" ;
-        lv2:name "low shelf gain" ;
-        lv2:default -0.4 ;
+        lv2:symbol "high_shelf_gain" ;
+        lv2:name "high gain" ;
+        lv2:default -1.2 ;
         lv2:minimum -18.0 ;
         lv2:maximum 0.0 ;
-        units:unit units:db ;
+        unit:unit unit:db ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
         lv2:index 14 ;
-        lv2:symbol "high_shelf_gain" ;
-        lv2:name "high shelf gain" ;
-        lv2:default -1.2 ;
-        lv2:minimum -18.0 ;
-        lv2:maximum 0.0 ;
-        units:unit units:db ;
-    ] ,
-    [
-        a lv2:InputPort, lv2:ControlPort ;
-        lv2:index 15 ;
         lv2:symbol "peak_gain" ;
         lv2:name "mid gain" ;
         lv2:default -1.7 ;
         lv2:minimum -18.0 ;
         lv2:maximum 0.0 ;
-        units:unit units:db ;
+        unit:unit unit:db ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
-        lv2:index 16 ;
-        lv2:symbol "stereo" ;
-        lv2:name "stereo" ;
+        lv2:index 15 ;
+        lv2:symbol "stereoWidth" ;
+        lv2:name "stereo width" ;
         lv2:default 1.000000 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;
-        lv2:index 17 ;
+        lv2:index 16 ;
         lv2:symbol "stereo_input" ;
         lv2:name "stereo input" ;
         lv2:default 0.000000 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;
+        lv2:portProperty lv2:toggled ;
     ] ;
 
     doap:name "Tal-Reverb-II" ;

--- a/mod-lv2-data/TAL-Reverb-2.lv2/TAL-Reverb-2.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/TAL-Reverb-2.ttl
@@ -1,0 +1,187 @@
+@prefix atom: <http://lv2plug.in/ns/ext/atom#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
+@prefix units: <http://lv2plug.in/ns/extensions/units#> .
+
+<urn:juce:TalReverb2>
+    a lv2:ReverbPlugin, lv2:Plugin ;
+    lv2:requiredFeature <http://lv2plug.in/ns/ext/buf-size#boundedBlockLength> ,
+                        <http://lv2plug.in/ns/ext/urid#map> ;
+    lv2:extensionData <http://lv2plug.in/ns/ext/options#interface> ,
+                      <http://lv2plug.in/ns/ext/state#interface> ,
+                      <http://kxstudio.sf.net/ns/lv2ext/programs#Interface> ;
+
+    ui:ui <urn:juce:TalReverb2#ExternalUI> ,
+          <urn:juce:TalReverb2#ParentUI> ;
+
+    lv2:port [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 0 ;
+        lv2:symbol "lv2_freewheel" ;
+        lv2:name "Freewheel" ;
+        lv2:default 0.0 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 1.0 ;
+        lv2:designation <http://lv2plug.in/ns/lv2core#freeWheeling> ;
+        lv2:portProperty lv2:toggled, <http://lv2plug.in/ns/ext/port-props#notOnGUI> ;
+    ] ;
+
+    lv2:port [
+        a lv2:InputPort, lv2:AudioPort ;
+        lv2:index 1 ;
+        lv2:symbol "lv2_audio_in_1" ;
+        lv2:name "Audio Input 1" ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:AudioPort ;
+        lv2:index 2 ;
+        lv2:symbol "lv2_audio_in_2" ;
+        lv2:name "Audio Input 2" ;
+    ] ;
+
+    lv2:port [
+        a lv2:OutputPort, lv2:AudioPort ;
+        lv2:index 3 ;
+        lv2:symbol "lv2_audio_out_1" ;
+        lv2:name "Audio Output 1" ;
+    ] ,
+    [
+        a lv2:OutputPort, lv2:AudioPort ;
+        lv2:index 4 ;
+        lv2:symbol "lv2_audio_out_2" ;
+        lv2:name "Audio Output 2" ;
+    ] ;
+
+    lv2:port [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 5 ;
+        lv2:symbol "unused" ;
+        lv2:name "unused" ;
+        lv2:default 0.000000 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 1.0 ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 6 ;
+        lv2:symbol "dry" ;
+        lv2:name "dry" ;
+        lv2:default 0.0 ;
+        lv2:minimum -96.0 ;
+        lv2:maximum 26.4 ;
+        units:unit units:db ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 7 ;
+        lv2:symbol "wet" ;
+        lv2:name "wet" ;
+        lv2:default -24.1 ;
+        lv2:minimum -96.0 ;
+        lv2:maximum 26.4 ;
+        units:unit units:db ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 8 ;
+        lv2:symbol "room_size" ;
+        lv2:name "room size" ;
+        lv2:default 0.752000 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 1.0 ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 9 ;
+        lv2:symbol "pre_delay" ;
+        lv2:name "pre delay" ;
+        lv2:default 37.0 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 1000.0 ;
+        units:unit units:ms ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 10 ;
+        lv2:symbol "low_shelf_frequency" ;
+        lv2:name "low shelf frequency" ;
+        lv2:default 257.0 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 10000.0 ;
+        units:unit units:hz ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 11 ;
+        lv2:symbol "high_shelf_frequency" ;
+        lv2:name "high shelf frequency" ;
+        lv2:default 3039.0 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 10000.0 ;
+        units:unit units:hz ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 12 ;
+        lv2:symbol "peak_frequency" ;
+        lv2:name "mid frequency" ;
+        lv2:default 2237.0 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 10000.0 ;
+        units:unit units:hz ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 13 ;
+        lv2:symbol "low_shelf_gain" ;
+        lv2:name "low shelf gain" ;
+        lv2:default -0.4 ;
+        lv2:minimum -18.0 ;
+        lv2:maximum 0.0 ;
+        units:unit units:db ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 14 ;
+        lv2:symbol "high_shelf_gain" ;
+        lv2:name "high shelf gain" ;
+        lv2:default -1.2 ;
+        lv2:minimum -18.0 ;
+        lv2:maximum 0.0 ;
+        units:unit units:db ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 15 ;
+        lv2:symbol "peak_gain" ;
+        lv2:name "mid gain" ;
+        lv2:default -1.7 ;
+        lv2:minimum -18.0 ;
+        lv2:maximum 0.0 ;
+        units:unit units:db ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 16 ;
+        lv2:symbol "stereo" ;
+        lv2:name "stereo" ;
+        lv2:default 1.000000 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 1.0 ;
+    ] ,
+    [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 17 ;
+        lv2:symbol "stereo_input" ;
+        lv2:name "stereo input" ;
+        lv2:default 0.000000 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 1.0 ;
+    ] ;
+
+    doap:name "Tal-Reverb-II" ;
+    doap:maintainer [ foaf:name "TAL-Togu Audio Line" ] .
+

--- a/mod-lv2-data/TAL-Reverb-2.lv2/manifest.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/manifest.ttl
@@ -1,0 +1,84 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix pset: <http://lv2plug.in/ns/ext/presets#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
+
+<urn:juce:TalReverb2>
+    a lv2:Plugin ;
+    lv2:binary <TAL-Reverb-2.so> ;
+    rdfs:seeAlso <TAL-Reverb-2.ttl> .
+
+<urn:juce:TalReverb2#ExternalUI>
+    a <http://kxstudio.sf.net/ns/lv2ext/external-ui#Widget> ;
+    ui:binary <TAL-Reverb-2.so> ;
+    lv2:requiredFeature <http://lv2plug.in/ns/ext/instance-access> ;
+    lv2:extensionData <http://kxstudio.sf.net/ns/lv2ext/programs#UIInterface> .
+
+<urn:juce:TalReverb2#ParentUI>
+    a ui:X11UI ;
+    ui:binary <TAL-Reverb-2.so> ;
+    lv2:requiredFeature <http://lv2plug.in/ns/ext/instance-access> ;
+    lv2:optionalFeature ui:noUserResize ;
+    lv2:extensionData <http://kxstudio.sf.net/ns/lv2ext/programs#UIInterface> .
+
+<urn:juce:TalReverb2#preset001>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "Gentle Drum Ambience" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset002>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "80's Plate" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset003>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "Big Wet Plate (no EQ)" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset004>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "Small Drum Plate" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset005>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "Dull Plate" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset006>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "Need some Air" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset007>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "Mid Plate" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset008>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "Airy Mono Plate" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset009>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "1100Hz Plate" ;
+    rdfs:seeAlso <presets.ttl> .
+
+<urn:juce:TalReverb2#preset010>
+    a pset:Preset ;
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+    rdfs:label "Short Plate" ;
+    rdfs:seeAlso <presets.ttl> .
+
+

--- a/mod-lv2-data/TAL-Reverb-2.lv2/manifest.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/manifest.ttl
@@ -1,84 +1,142 @@
 @prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+
 @prefix pset: <http://lv2plug.in/ns/ext/presets#> .
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
 @prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
+
+
 
 <urn:juce:TalReverb2>
     a lv2:Plugin ;
     lv2:binary <TAL-Reverb-2.so> ;
     rdfs:seeAlso <TAL-Reverb-2.ttl> .
 
-<urn:juce:TalReverb2#ExternalUI>
-    a <http://kxstudio.sf.net/ns/lv2ext/external-ui#Widget> ;
-    ui:binary <TAL-Reverb-2.so> ;
-    lv2:requiredFeature <http://lv2plug.in/ns/ext/instance-access> ;
-    lv2:extensionData <http://kxstudio.sf.net/ns/lv2ext/programs#UIInterface> .
-
-<urn:juce:TalReverb2#ParentUI>
-    a ui:X11UI ;
-    ui:binary <TAL-Reverb-2.so> ;
-    lv2:requiredFeature <http://lv2plug.in/ns/ext/instance-access> ;
-    lv2:optionalFeature ui:noUserResize ;
-    lv2:extensionData <http://kxstudio.sf.net/ns/lv2ext/programs#UIInterface> .
-
-<urn:juce:TalReverb2#preset001>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "Gentle Drum Ambience" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset002>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "80's Plate" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset003>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "Big Wet Plate (no EQ)" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset004>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "Small Drum Plate" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset005>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "Dull Plate" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset006>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "Need some Air" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset007>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "Mid Plate" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset008>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "Airy Mono Plate" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset009>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "1100Hz Plate" ;
-    rdfs:seeAlso <presets.ttl> .
-
-<urn:juce:TalReverb2#preset010>
-    a pset:Preset ;
-    lv2:appliesTo <urn:juce:TalReverb2> ;
-    rdfs:label "Short Plate" ;
-    rdfs:seeAlso <presets.ttl> .
 
 
+#<urn:juce:TalReverb2#preset001>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "Gentle Drum Ambience" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset002>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "80's Plate" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset003>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "Big Wet Plate (no EQ)" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset004>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "Small Drum Plate" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset005>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "Dull Plate" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset006>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "Need some Air" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset007>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "Mid Plate" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset008>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "Airy Mono Plate" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset009>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "1100Hz Plate" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#<urn:juce:TalReverb2#preset010>
+#
+#    a pset:Preset ;
+#
+#    lv2:appliesTo <urn:juce:TalReverb2> ;
+#
+#    rdfs:label "Short Plate" ;
+#
+#    rdfs:seeAlso <presets.ttl> .
+#
+#
+#
+#
+#
+#
+#<urn:juce:TalReverb2> <http://moddevices.com/ns/mod#releaseNumber> 5 .
+#<urn:juce:TalReverb2> <http://moddevices.com/ns/mod#builderVersion> 1 .

--- a/mod-lv2-data/TAL-Reverb-2.lv2/manifest.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/manifest.ttl
@@ -7,18 +7,18 @@
 @prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
 
 
-<urn:juce:TalReverb2>
+<http://moddevices.com/plugins/tal-reverb-2>
     a lv2:Plugin ;
     lv2:binary <TAL-Reverb-2.so> ;
     rdfs:seeAlso <TAL-Reverb-2.ttl> .
 
 
 
-<urn:juce:TalReverb2#preset001>
+<http://moddevices.com/plugins/tal-reverb-2#preset001>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "Gentle Drum Ambience" ;
 
@@ -26,11 +26,11 @@
 
 
 
-<urn:juce:TalReverb2#preset002>
+<http://moddevices.com/plugins/tal-reverb-2#preset002>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "80's Plate" ;
 
@@ -38,11 +38,11 @@
 
 
 
-<urn:juce:TalReverb2#preset003>
+<http://moddevices.com/plugins/tal-reverb-2#preset003>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "Big Wet Plate (no EQ)" ;
 
@@ -50,11 +50,11 @@
 
 
 
-<urn:juce:TalReverb2#preset004>
+<http://moddevices.com/plugins/tal-reverb-2#preset004>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "Small Drum Plate" ;
 
@@ -62,11 +62,11 @@
 
 
 
-<urn:juce:TalReverb2#preset005>
+<http://moddevices.com/plugins/tal-reverb-2#preset005>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "Dull Plate" ;
 
@@ -74,11 +74,11 @@
 
 
 
-<urn:juce:TalReverb2#preset006>
+<http://moddevices.com/plugins/tal-reverb-2#preset006>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "Need some Air" ;
 
@@ -86,11 +86,11 @@
 
 
 
-<urn:juce:TalReverb2#preset007>
+<http://moddevices.com/plugins/tal-reverb-2#preset007>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "Mid Plate" ;
 
@@ -98,11 +98,11 @@
 
 
 
-<urn:juce:TalReverb2#preset008>
+<http://moddevices.com/plugins/tal-reverb-2#preset008>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "Airy Mono Plate" ;
 
@@ -110,11 +110,11 @@
 
 
 
-<urn:juce:TalReverb2#preset009>
+<http://moddevices.com/plugins/tal-reverb-2#preset009>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "1100Hz Plate" ;
 
@@ -122,11 +122,11 @@
 
 
 
-<urn:juce:TalReverb2#preset010>
+<http://moddevices.com/plugins/tal-reverb-2#preset010>
 
     a pset:Preset ;
 
-    lv2:appliesTo <urn:juce:TalReverb2> ;
+    lv2:appliesTo <http://moddevices.com/plugins/tal-reverb-2> ;
 
     rdfs:label "Short Plate" ;
 

--- a/mod-lv2-data/TAL-Reverb-2.lv2/manifest.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/manifest.ttl
@@ -7,7 +7,6 @@
 @prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
 
 
-
 <urn:juce:TalReverb2>
     a lv2:Plugin ;
     lv2:binary <TAL-Reverb-2.so> ;
@@ -15,128 +14,120 @@
 
 
 
-#<urn:juce:TalReverb2#preset001>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "Gentle Drum Ambience" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset002>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "80's Plate" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset003>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "Big Wet Plate (no EQ)" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset004>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "Small Drum Plate" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset005>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "Dull Plate" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset006>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "Need some Air" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset007>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "Mid Plate" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset008>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "Airy Mono Plate" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset009>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "1100Hz Plate" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#<urn:juce:TalReverb2#preset010>
-#
-#    a pset:Preset ;
-#
-#    lv2:appliesTo <urn:juce:TalReverb2> ;
-#
-#    rdfs:label "Short Plate" ;
-#
-#    rdfs:seeAlso <presets.ttl> .
-#
-#
-#
-#
-#
-#
-#<urn:juce:TalReverb2> <http://moddevices.com/ns/mod#releaseNumber> 5 .
-#<urn:juce:TalReverb2> <http://moddevices.com/ns/mod#builderVersion> 1 .
+<urn:juce:TalReverb2#preset001>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "Gentle Drum Ambience" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset002>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "80's Plate" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset003>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "Big Wet Plate (no EQ)" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset004>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "Small Drum Plate" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset005>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "Dull Plate" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset006>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "Need some Air" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset007>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "Mid Plate" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset008>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "Airy Mono Plate" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset009>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "1100Hz Plate" ;
+
+    rdfs:seeAlso <presets.ttl> .
+
+
+
+<urn:juce:TalReverb2#preset010>
+
+    a pset:Preset ;
+
+    lv2:appliesTo <urn:juce:TalReverb2> ;
+
+    rdfs:label "Short Plate" ;
+
+    rdfs:seeAlso <presets.ttl> .

--- a/mod-lv2-data/TAL-Reverb-2.lv2/presets.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/presets.ttl
@@ -1,0 +1,1219 @@
+@prefix atom:  <http://lv2plug.in/ns/ext/atom#> .
+@prefix lv2:   <http://lv2plug.in/ns/lv2core#> .
+@prefix pset:  <http://lv2plug.in/ns/ext/presets#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix state: <http://lv2plug.in/ns/ext/state#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:juce:TalReverb2#preset001> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="0" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.130000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.660000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.180000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.088000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.632000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.544000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 0.936000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 0.828000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.764000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 1.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset002> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="1" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.209000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.660000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.060000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.424000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.368000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 0.788000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.368000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 0.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset003> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="2" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.161000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.752000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.132000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.024000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.492000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 0.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset004> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="3" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.335000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.308000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.120000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.176000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.444000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.300000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 0.724000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 0.488000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 1.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset005> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="4" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.242000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.632000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.160000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.328000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.720000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.568000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 0.216000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.360000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 1.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset006> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="5" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.149000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.688000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.120000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.212000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.536000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 0.248000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.644000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 0.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset007> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="6" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.371000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.604000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.208000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.324000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.272000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.576000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 0.764000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.112000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 1.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset008> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="7" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.441000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.732000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.072000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.180000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.428000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.320000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 0.356000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 0.380000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 0.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset009> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="8" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.404000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.600000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.212000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.352000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.360000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.264000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 0.000000 ;
+    ] .
+
+<urn:juce:TalReverb2#preset010> a pset:Preset ;
+    state:state [
+        <urn:juce:stateString>
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tal curprogram="9" version="1">
+  <programs>
+    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
+             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
+             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
+             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
+             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
+             stereowidth="1" realstereomode="1"/>
+    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
+             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
+             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
+             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
+             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
+    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
+             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
+             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
+             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
+             peakgain="1" stereowidth="1" realstereomode="0"/>
+    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
+             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
+             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
+             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
+             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
+             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
+             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
+             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
+             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
+    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
+             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
+             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
+             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
+             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
+             realstereomode="0"/>
+    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
+             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
+             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
+             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
+             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
+             realstereomode="1"/>
+    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
+             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
+             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
+             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
+             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
+             realstereomode="0"/>
+    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
+             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
+             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
+             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
+             stereowidth="1" realstereomode="0"/>
+    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
+             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
+             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
+             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
+             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
+  </programs>
+</tal>
+"""
+    ] ;
+
+    lv2:port [
+        lv2:symbol "unused" ;
+        pset:value 0.000000 ;
+    ] ,
+    [
+        lv2:symbol "dry" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "wet" ;
+        pset:value 0.478000 ;
+    ] ,
+    [
+        lv2:symbol "room_size" ;
+        pset:value 0.104000 ;
+    ] ,
+    [
+        lv2:symbol "pre_delay" ;
+        pset:value 0.136000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_frequency" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_frequency" ;
+        pset:value 0.500000 ;
+    ] ,
+    [
+        lv2:symbol "peak_frequency" ;
+        pset:value 0.536000 ;
+    ] ,
+    [
+        lv2:symbol "low_shelf_gain" ;
+        pset:value 0.492000 ;
+    ] ,
+    [
+        lv2:symbol "high_shelf_gain" ;
+        pset:value 0.356000 ;
+    ] ,
+    [
+        lv2:symbol "peak_gain" ;
+        pset:value 0.172000 ;
+    ] ,
+    [
+        lv2:symbol "stereo" ;
+        pset:value 1.000000 ;
+    ] ,
+    [
+        lv2:symbol "stereo_input" ;
+        pset:value 1.000000 ;
+    ] .
+
+

--- a/mod-lv2-data/TAL-Reverb-2.lv2/presets.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/presets.ttl
@@ -6,7 +6,7 @@
 @prefix state: <http://lv2plug.in/ns/ext/state#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 
-<urn:juce:TalReverb2#preset001> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset001> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.0 ;
@@ -56,7 +56,7 @@
         pset:value 1.000000 ;
     ] .
 
-<urn:juce:TalReverb2#preset002> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset002> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.0 ;
@@ -106,7 +106,7 @@
         pset:value 0.0 ;
     ] .
 
-<urn:juce:TalReverb2#preset003> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset003> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.0 ;
@@ -156,7 +156,7 @@
         pset:value 0.000000 ;
     ] .
 
-<urn:juce:TalReverb2#preset004> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset004> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.0 ;
@@ -206,7 +206,7 @@
         pset:value 1.000000 ;
     ] .
 
-<urn:juce:TalReverb2#preset005> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset005> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.000000 ;
@@ -256,7 +256,7 @@
         pset:value 1.000000 ;
     ] .
 
-<urn:juce:TalReverb2#preset006> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset006> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.0 ;
@@ -306,7 +306,7 @@
         pset:value 0.000000 ;
     ] .
 
-<urn:juce:TalReverb2#preset007> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset007> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.0 ;
@@ -356,7 +356,7 @@
         pset:value 1.000000 ;
     ] .
 
-<urn:juce:TalReverb2#preset008> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset008> a pset:Preset ;
 
     lv2:port [
         lv2:symbol "dry" ;
@@ -407,7 +407,7 @@
         pset:value 0.000000 ;
     ] .
 
-<urn:juce:TalReverb2#preset009> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset009> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.0 ;
@@ -457,7 +457,7 @@
         pset:value 0.000000 ;
     ] .
 
-<urn:juce:TalReverb2#preset010> a pset:Preset ;
+<http://moddevices.com/plugins/tal-reverb-2#preset010> a pset:Preset ;
     lv2:port [
         lv2:symbol "dry" ;
         pset:value 0.0 ;

--- a/mod-lv2-data/TAL-Reverb-2.lv2/presets.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/presets.ttl
@@ -7,84 +7,13 @@
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 
 <urn:juce:TalReverb2#preset001> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="0" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.130000 ;
+        pset:value -24.1 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -92,31 +21,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.180000 ;
+        pset:value 37.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.088000 ;
+        pset:value 257.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.632000 ;
+        pset:value 3039.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.544000 ;
+        pset:value 2237.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 0.936000 ;
+        pset:value -0.4 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 0.828000 ;
+        pset:value -1.2 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.764000 ;
+        pset:value -1.7 ;
     ] ,
     [
         lv2:symbol "stereo" ;
@@ -128,84 +57,13 @@
     ] .
 
 <urn:juce:TalReverb2#preset002> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="1" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.209000 ;
+        pset:value -17.6 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -213,120 +71,49 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.060000 ;
+        pset:value 10.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.500000 ;
+        pset:value 1909.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.424000 ;
+        pset:value 1434.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.368000 ;
+        pset:value 1148.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 1.000000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 0.788000 ;
+        pset:value -1.5 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.368000 ;
+        pset:value -4.9 ;
     ] ,
     [
         lv2:symbol "stereo" ;
-        pset:value 1.000000 ;
+        pset:value 1.0 ;
     ] ,
     [
         lv2:symbol "stereo_input" ;
-        pset:value 0.000000 ;
+        pset:value 0.0 ;
     ] .
 
 <urn:juce:TalReverb2#preset003> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="2" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.161000 ;
+        pset:value -21.4 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -334,31 +121,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.132000 ;
+        pset:value 25.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.024000 ;
+        pset:value 138.00 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 1.000000 ;
+        pset:value 10000.00 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.492000 ;
+        pset:value 1853.00 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 1.000000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 1.000000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 1.000000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "stereo" ;
@@ -370,84 +157,13 @@
     ] .
 
 <urn:juce:TalReverb2#preset004> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="3" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.335000 ;
+        pset:value -9.4 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -455,31 +171,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.120000 ;
+        pset:value 22.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.176000 ;
+        pset:value 461.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.444000 ;
+        pset:value 1549.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.300000 ;
+        pset:value 858.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 0.724000 ;
+        pset:value -1.9 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 0.488000 ;
+        pset:value -3.8 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.000000 ;
+        pset:value -18.0 ;
     ] ,
     [
         lv2:symbol "stereo" ;
@@ -491,84 +207,13 @@
     ] .
 
 <urn:juce:TalReverb2#preset005> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="4" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
+        lv2:symbol "dry" ;
         pset:value 0.000000 ;
     ] ,
     [
-        lv2:symbol "dry" ;
-        pset:value 0.500000 ;
-    ] ,
-    [
         lv2:symbol "wet" ;
-        pset:value 0.242000 ;
+        pset:value -15.3 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -576,31 +221,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.160000 ;
+        pset:value -32.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.328000 ;
+        pset:value 970.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.720000 ;
+        pset:value 4083.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.568000 ;
+        pset:value 2435.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 1.000000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 0.216000 ;
+        pset:value -6.6 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.360000 ;
+        pset:value -5.0 ;
     ] ,
     [
         lv2:symbol "stereo" ;
@@ -612,84 +257,13 @@
     ] .
 
 <urn:juce:TalReverb2#preset006> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="5" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.149000 ;
+        pset:value -22.4 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -697,31 +271,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.120000 ;
+        pset:value 22.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.212000 ;
+        pset:value 562.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.500000 ;
+        pset:value 1909.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.536000 ;
+        pset:value 2174.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 0.248000 ;
+        pset:value -6.2 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 1.000000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.644000 ;
+        pset:value -2.5 ;
     ] ,
     [
         lv2:symbol "stereo" ;
@@ -733,84 +307,13 @@
     ] .
 
 <urn:juce:TalReverb2#preset007> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="6" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.371000 ;
+        pset:value -7.3 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -818,31 +321,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.208000 ;
+        pset:value 45.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.324000 ;
+        pset:value 954.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.272000 ;
+        pset:value 755.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.576000 ;
+        pset:value 2504.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 0.764000 ;
+        pset:value -1.7 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 0.000000 ;
+        pset:value -18.0 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.112000 ;
+        pset:value -8.4 ;
     ] ,
     [
         lv2:symbol "stereo" ;
@@ -854,84 +357,14 @@
     ] .
 
 <urn:juce:TalReverb2#preset008> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="7" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
 
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.441000 ;
+        pset:value -3.3 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -939,31 +372,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.072000 ;
+        pset:value 12.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.180000 ;
+        pset:value 472.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.428000 ;
+        pset:value 1457.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.320000 ;
+        pset:value 937.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 0.356000 ;
+        pset:value -5.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 0.380000 ;
+        pset:value -4.8 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.000000 ;
+        pset:value -18.0 ;
     ] ,
     [
         lv2:symbol "stereo" ;
@@ -975,84 +408,13 @@
     ] .
 
 <urn:juce:TalReverb2#preset009> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="8" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.404000 ;
+        pset:value -5.4 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -1060,31 +422,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.212000 ;
+        pset:value 46.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.352000 ;
+        pset:value 1074.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.360000 ;
+        pset:value 1110.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 1.000000 ;
+        pset:value 10000.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 0.000000 ;
+        pset:value -18.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 0.000000 ;
+        pset:value -18.0 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.264000 ;
+        pset:value -6.0 ;
     ] ,
     [
         lv2:symbol "stereo" ;
@@ -1096,84 +458,13 @@
     ] .
 
 <urn:juce:TalReverb2#preset010> a pset:Preset ;
-    state:state [
-        <urn:juce:stateString>
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-
-<tal curprogram="9" version="1">
-  <programs>
-    <program programname="Gentle Drum Ambience" dry="0.5" wet="0.13000001013278961182"
-             roomsize="0.66000002622604370117" predelay="0.18000000715255737305"
-             lowshelffrequency="0.088000006973743438721" highshelffrequency="0.63200002908706665039"
-             peakfrequency="0.54400002956390380859" lowshelfgain="0.93600004911422729492"
-             highshelfgain="0.82800006866455078125" peakgain="0.76400005817413330078"
-             stereowidth="1" realstereomode="1"/>
-    <program programname="80's Plate" dry="0.5" wet="0.20900000631809234619"
-             roomsize="0.66000002622604370117" predelay="0.060000002384185791016"
-             lowshelffrequency="0.5" highshelffrequency="0.42400002479553222656"
-             peakfrequency="0.368000030517578125" lowshelfgain="1" highshelfgain="0.78800004720687866211"
-             peakgain="0.368000030517578125" stereowidth="1" realstereomode="0"/>
-    <program programname="Big Wet Plate (no EQ)" dry="0.5" wet="0.16100001335144042969"
-             roomsize="0.75200003385543823242" predelay="0.1319999992847442627"
-             lowshelffrequency="0.024000000208616256714" highshelffrequency="1"
-             peakfrequency="0.49200001358985900879" lowshelfgain="1" highshelfgain="1"
-             peakgain="1" stereowidth="1" realstereomode="0"/>
-    <program programname="Small Drum Plate" dry="0.5" wet="0.33500000834465026855"
-             roomsize="0.30800002813339233398" predelay="0.12000000476837158203"
-             lowshelffrequency="0.17600001394748687744" highshelffrequency="0.44400003552436828613"
-             peakfrequency="0.30000001192092895508" lowshelfgain="0.72400003671646118164"
-             highshelfgain="0.48800003528594970703" peakgain="0" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Dull Plate" dry="0.5" wet="0.24200001358985900879"
-             roomsize="0.63200002908706665039" predelay="0.16000001132488250732"
-             lowshelffrequency="0.32800000905990600586" highshelffrequency="0.72000002861022949219"
-             peakfrequency="0.56800001859664916992" lowshelfgain="1" highshelfgain="0.21600000560283660889"
-             peakgain="0.36000001430511474609" stereowidth="1" realstereomode="1"/>
-    <program programname="Need some Air" dry="0.5" wet="0.14900000393390655518"
-             roomsize="0.68800002336502075195" predelay="0.12000000476837158203"
-             lowshelffrequency="0.21200001239776611328" highshelffrequency="0.5"
-             peakfrequency="0.53600001335144042969" lowshelfgain="0.24800001084804534912"
-             highshelfgain="1" peakgain="0.64400005340576171875" stereowidth="1"
-             realstereomode="0"/>
-    <program programname="Mid Plate" dry="0.5" wet="0.37100002169609069824"
-             roomsize="0.60400003194808959961" predelay="0.20800000429153442383"
-             lowshelffrequency="0.32400000095367431641" highshelffrequency="0.2720000147819519043"
-             peakfrequency="0.57600003480911254883" lowshelfgain="0.76400005817413330078"
-             highshelfgain="0" peakgain="0.11200000345706939697" stereowidth="1"
-             realstereomode="1"/>
-    <program programname="Airy Mono Plate" dry="0.5" wet="0.4410000145435333252"
-             roomsize="0.73200005292892456055" predelay="0.072000004351139068604"
-             lowshelffrequency="0.18000000715255737305" highshelffrequency="0.42800003290176391602"
-             peakfrequency="0.32000002264976501465" lowshelfgain="0.35600000619888305664"
-             highshelfgain="0.38000002503395080566" peakgain="0" stereowidth="0"
-             realstereomode="0"/>
-    <program programname="1100Hz Plate" dry="0.5" wet="0.40400001406669616699"
-             roomsize="0.60000002384185791016" predelay="0.21200001239776611328"
-             lowshelffrequency="0.35200002789497375488" highshelffrequency="0.36000001430511474609"
-             peakfrequency="1" lowshelfgain="0" highshelfgain="0" peakgain="0.26399999856948852539"
-             stereowidth="1" realstereomode="0"/>
-    <program programname="Short Plate" dry="0.5" wet="0.4780000150203704834"
-             roomsize="0.10400000214576721191" predelay="0.13600000739097595215"
-             lowshelffrequency="0.5" highshelffrequency="0.5" peakfrequency="0.53600001335144042969"
-             lowshelfgain="0.49200001358985900879" highshelfgain="0.35600000619888305664"
-             peakgain="0.17200000584125518799" stereowidth="1" realstereomode="1"/>
-  </programs>
-</tal>
-"""
-    ] ;
-
     lv2:port [
-        lv2:symbol "unused" ;
-        pset:value 0.000000 ;
-    ] ,
-    [
         lv2:symbol "dry" ;
-        pset:value 0.500000 ;
+        pset:value 0.0 ;
     ] ,
     [
         lv2:symbol "wet" ;
-        pset:value 0.478000 ;
+        pset:value -1.2 ;
     ] ,
     [
         lv2:symbol "room_size" ;
@@ -1181,31 +472,31 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value 0.136000 ;
+        pset:value 26.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;
-        pset:value 0.500000 ;
+        pset:value 1909.0 ;
     ] ,
     [
         lv2:symbol "high_shelf_frequency" ;
-        pset:value 0.500000 ;
+        pset:value 1909.0 ;
     ] ,
     [
         lv2:symbol "peak_frequency" ;
-        pset:value 0.536000 ;
+        pset:value 2174.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_gain" ;
-        pset:value 0.492000 ;
+        pset:value -3.8 ;
     ] ,
     [
         lv2:symbol "high_shelf_gain" ;
-        pset:value 0.356000 ;
+        pset:value -5.0 ;
     ] ,
     [
         lv2:symbol "peak_gain" ;
-        pset:value 0.172000 ;
+        pset:value -7.3 ;
     ] ,
     [
         lv2:symbol "stereo" ;

--- a/mod-lv2-data/TAL-Reverb-2.lv2/presets.ttl
+++ b/mod-lv2-data/TAL-Reverb-2.lv2/presets.ttl
@@ -167,7 +167,7 @@
     ] ,
     [
         lv2:symbol "room_size" ;
-        pset:value 0.308000 ;
+        pset:value 0.308 ;
     ] ,
     [
         lv2:symbol "pre_delay" ;
@@ -221,7 +221,7 @@
     ] ,
     [
         lv2:symbol "pre_delay" ;
-        pset:value -32.0 ;
+        pset:value 32.0 ;
     ] ,
     [
         lv2:symbol "low_shelf_frequency" ;

--- a/ports/tal-reverb-2/source/Engine/Params.h
+++ b/ports/tal-reverb-2/source/Engine/Params.h
@@ -36,7 +36,10 @@ Parameter table
 enum SYNTHPARAMETERS
 {
   // Controllable values [0.0..1.0
-  DRY = 0,
+#ifndef __MOD_DEVICES__
+  UNUSED= 0,
+#endif
+  DRY,
   WET,
 
   DECAYTIME,

--- a/ports/tal-reverb-2/source/Engine/Params.h
+++ b/ports/tal-reverb-2/source/Engine/Params.h
@@ -16,7 +16,7 @@
 
 	You should have received a copy of the GPL along with this
 	program. If not, go to http://www.gnu.org/licenses/gpl.html
-	or write to the Free Software Foundation, Inc.,  
+	or write to the Free Software Foundation, Inc.,
 	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 	==============================================================================
  */
@@ -36,8 +36,7 @@ Parameter table
 enum SYNTHPARAMETERS
 {
   // Controllable values [0.0..1.0
-  UNUSED= 0,
-  DRY,
+  DRY = 0,
   WET,
 
   DECAYTIME,

--- a/ports/tal-reverb-2/source/Engine/Reverb.h
+++ b/ports/tal-reverb-2/source/Engine/Reverb.h
@@ -25,6 +25,9 @@
 #if !defined(__TalReverb_h)
 #define __TalReverb_h
 
+
+#define __MOD_DEVICES__ 1
+
 #include "AllPassFilter.h"
 #include "CombFilter.h"
 #include "NoiseGenerator.h"
@@ -194,7 +197,7 @@ public:
 
 	void setPreDelay(float preDelayTime)
 	{
-		this->preDelayTime = preDelayTime;
+		this->preDelayTime = preDelayTime * 0.001;
 	}
 #else 
 	void setDecayTime(float decayTime)

--- a/ports/tal-reverb-2/source/Engine/Reverb.h
+++ b/ports/tal-reverb-2/source/Engine/Reverb.h
@@ -186,7 +186,17 @@ public:
 		delete talEqR;
 	}
 
+#ifdef __MOD_DEVICES__
+	void setDecayTime(float decayTime)
+	{
+		this->decayTime = decayTime * 0.00099;
+	}
 
+	void setPreDelay(float preDelayTime)
+	{
+		this->preDelayTime = preDelayTime;
+	}
+#else 
 	void setDecayTime(float decayTime)
 	{
 		this->decayTime = audioUtils.getLogScaledValueInverted(decayTime) * 0.99f;
@@ -196,7 +206,7 @@ public:
 	{
 		this->preDelayTime = audioUtils.getLogScaledValue(preDelayTime);
 	}
-
+#endif
 	void setStereoMode(bool stereoMode)
 	{
 		this->stereoMode = stereoMode;

--- a/ports/tal-reverb-2/source/Engine/Reverb.h
+++ b/ports/tal-reverb-2/source/Engine/Reverb.h
@@ -186,22 +186,17 @@ public:
 		delete talEqR;
 	}
 
-#ifdef __MOD_DEVICES__
-	void setDecayTime(float decayTime)
-	{
-		this->decayTime = decayTime * 0.00099;
-	}
-
-	void setPreDelay(float preDelayTime)
-	{
-		this->preDelayTime = preDelayTime * 0.001;
-	}
-#else 
 	void setDecayTime(float decayTime)
 	{
 		this->decayTime = audioUtils.getLogScaledValueInverted(decayTime) * 0.99f;
 	}
 
+#ifdef __MOD_DEVICES__
+	void setPreDelay(float preDelayTime)
+	{
+		this->preDelayTime = preDelayTime * 0.001;
+	}
+#else
 	void setPreDelay(float preDelayTime)
 	{
 		this->preDelayTime = audioUtils.getLogScaledValue(preDelayTime);

--- a/ports/tal-reverb-2/source/Engine/Reverb.h
+++ b/ports/tal-reverb-2/source/Engine/Reverb.h
@@ -25,9 +25,6 @@
 #if !defined(__TalReverb_h)
 #define __TalReverb_h
 
-
-#define __MOD_DEVICES__ 1
-
 #include "AllPassFilter.h"
 #include "CombFilter.h"
 #include "NoiseGenerator.h"

--- a/ports/tal-reverb-2/source/Engine/ReverbEngine.h
+++ b/ports/tal-reverb-2/source/Engine/ReverbEngine.h
@@ -131,7 +131,7 @@ public:
 
 	void setStereoMode(float stereoMode)
 	{
-		reverb->setStereoMode(stereoMode);
+		reverb->setStereoMode(stereoMode > 0.0f ? true : false);
 	}
 
 	void setSampleRate(float sampleRate)

--- a/ports/tal-reverb-2/source/Engine/ReverbEngine.h
+++ b/ports/tal-reverb-2/source/Engine/ReverbEngine.h
@@ -61,9 +61,22 @@ public:
 
 		delete noiseGenerator;
 	}
-
+#ifdef __MOD_DEVICES__
 	void setDry(float dry)
 	{
+        dry = (dry + 122.4 ) / 122.4;
+		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
+	}
+
+	void setWet(float wet)
+	{
+        wet = (wet + 122.4 ) / 122.4;
+		this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
+	}
+#else
+	void setDry(float dry)
+	{
+        lowShelfGain = (lowShelfGain + 18.0 ) / 36.0;
 		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
 	}
 
@@ -71,7 +84,7 @@ public:
 	{
 		this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
 	}
-
+#endif
 	void setDecayTime(float decayTime)
 	{
 		reverb->setDecayTime(decayTime);
@@ -119,7 +132,7 @@ public:
 
 	void setStereoMode(float stereoMode)
 	{
-		reverb->setStereoMode(stereoMode > 0.0f ? true : false);
+		reverb->setStereoMode(stereoMode);
 	}
 
 	void setSampleRate(float sampleRate)

--- a/ports/tal-reverb-2/source/Engine/ReverbEngine.h
+++ b/ports/tal-reverb-2/source/Engine/ReverbEngine.h
@@ -16,7 +16,7 @@
 
 	You should have received a copy of the GPL along with this
 	program. If not, go to http://www.gnu.org/licenses/gpl.html
-	or write to the Free Software Foundation, Inc.,  
+	or write to the Free Software Foundation, Inc.,
 	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 	==============================================================================
  */
@@ -25,13 +25,15 @@
 #if !defined(__ReverbEngine_h)
 #define __ReverbEngine_h
 
+#define __MOD_DEVICES__ 1
+
 #include "Reverb.h"
 #include "AudioUtils.h"
 #include "Params.h"
 #include "ParamChangeUtil.h"
 #include "NoiseGenerator.h"
 
-class ReverbEngine 
+class ReverbEngine
 {
 public:
 	float *param;
@@ -48,7 +50,7 @@ public:
 
 	AudioUtils audioUtils;
 
-	ReverbEngine(float sampleRate) 
+	ReverbEngine(float sampleRate)
 	{
 		Params *params= new Params();
 		this->param= params->parameters;
@@ -64,19 +66,18 @@ public:
 #ifdef __MOD_DEVICES__
 	void setDry(float dry)
 	{
-        dry = (dry + 122.4 ) / 122.4;
+        dry = (dry + 96.0) / (26.4 + 96.0);
 		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
 	}
 
 	void setWet(float wet)
 	{
-        wet = (wet + 122.4 ) / 122.4;
+        wet = (wet + 96.0) / (26.4 + 96.0);
 		this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
 	}
 #else
 	void setDry(float dry)
 	{
-        lowShelfGain = (lowShelfGain + 18.0 ) / 36.0;
 		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
 	}
 

--- a/ports/tal-reverb-2/source/Engine/ReverbEngine.h
+++ b/ports/tal-reverb-2/source/Engine/ReverbEngine.h
@@ -64,13 +64,13 @@ public:
 #ifdef __MOD_DEVICES__
 	void setDry(float dry)
 	{
-        dry = (dry + 96.0) / (26.4 + 96.0);
+		dry = (dry + 96.0) / (26.4 + 96.0);
 		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
 	}
 
 	void setWet(float wet)
 	{
-        wet = (wet + 96.0) / (26.4 + 96.0);
+		wet = (wet + 96.0) / (26.4 + 96.0);
 		this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
 	}
 #else

--- a/ports/tal-reverb-2/source/Engine/ReverbEngine.h
+++ b/ports/tal-reverb-2/source/Engine/ReverbEngine.h
@@ -48,138 +48,138 @@ public:
 
 	AudioUtils audioUtils;
 
-	ReverbEngine(float sampleRate)
-	{
-		Params *params= new Params();
-		this->param= params->parameters;
-		initialize(sampleRate);
-	}
+    ReverbEngine(float sampleRate)
+    {
+        Params *params= new Params();
+        this->param= params->parameters;
+        initialize(sampleRate);
+    }
 
-	~ReverbEngine()
-	{
-		delete reverb;
+    ~ReverbEngine()
+    {
+        delete reverb;
 
-		delete noiseGenerator;
-	}
+        delete noiseGenerator;
+    }
 #ifdef __MOD_DEVICES__
-	void setDry(float dry)
-	{
+    void setDry(float dry)
+    {
         dry = (dry + 96.0) / (26.4 + 96.0);
-		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
-	}
+        this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
+    }
 
 	void setWet(float wet)
-	{
+    {
         wet = (wet + 96.0) / (26.4 + 96.0);
-		this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
-	}
+        this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
+    }
 #else
-	void setDry(float dry)
-	{
-		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
-	}
+    void setDry(float dry)
+    {
+        this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
+    }
 
-	void setWet(float wet)
-	{
-		this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
-	}
+    void setWet(float wet)
+    {
+        this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
+    }
 #endif
-	void setDecayTime(float decayTime)
-	{
-		reverb->setDecayTime(decayTime);
-	}
+    void setDecayTime(float decayTime)
+    {
+        reverb->setDecayTime(decayTime);
+    }
 
-	void setPreDelay(float preDelay)
-	{
-		reverb->setPreDelay(preDelay);
-	}
+    void setPreDelay(float preDelay)
+    {
+        reverb->setPreDelay(preDelay);
+    }
 
-	void setLowShelfGain(float lowShelfGain)
-	{
-		reverb->setLowShelfGain(lowShelfGain);
-	}
+    void setLowShelfGain(float lowShelfGain)
+    {
+        reverb->setLowShelfGain(lowShelfGain);
+    }
 
-	void setHighShelfGain(float highShelfGain)
-	{
-		reverb->setHighShelfGain(highShelfGain);
-	}
+    void setHighShelfGain(float highShelfGain)
+    {
+        reverb->setHighShelfGain(highShelfGain);
+    }
 
-	void setLowShelfFrequency(float lowShelfFrequency)
-	{
-		reverb->setLowShelfFrequency(lowShelfFrequency);
-	}
+    void setLowShelfFrequency(float lowShelfFrequency)
+    {
+        reverb->setLowShelfFrequency(lowShelfFrequency);
+    }
 
-	void setHighShelfFrequency(float highShelfFrequency)
-	{
-		reverb->setHighShelfFrequency(highShelfFrequency);
-	}
+    void setHighShelfFrequency(float highShelfFrequency)
+    {
+        reverb->setHighShelfFrequency(highShelfFrequency);
+    }
 
-	void setPeakFrequency(float peakFrequency)
-	{
-		reverb->setPeakFrequency(peakFrequency);
-	}
+    void setPeakFrequency(float peakFrequency)
+    {
+        reverb->setPeakFrequency(peakFrequency);
+    }
 
-	void setPeakGain(float peakGain)
-	{
-		reverb->setPeakGain(peakGain);
-	}
+    void setPeakGain(float peakGain)
+    {
+        reverb->setPeakGain(peakGain);
+    }
 
-	void setStereoWidth(float stereoWidth)
-	{
-		this->stereoWidth = stereoWidth;
-	}
+    void setStereoWidth(float stereoWidth)
+    {
+        this->stereoWidth = stereoWidth;
+    }
 
-	void setStereoMode(float stereoMode)
-	{
-		reverb->setStereoMode(stereoMode > 0.0f ? true : false);
-	}
+    void setStereoMode(float stereoMode)
+    {
+        reverb->setStereoMode(stereoMode > 0.0f ? true : false);
+    }
 
-	void setSampleRate(float sampleRate)
-	{
-		initialize(sampleRate);
-	}
+    void setSampleRate(float sampleRate)
+    {
+        initialize(sampleRate);
+    }
 
-	void initialize(float sampleRate)
-	{
+    void initialize(float sampleRate)
+    {
         if (sampleRate <= 0)
         {
             sampleRate = 44100.0f;
         }
 
-		reverb = new TalReverb((int)sampleRate);
+        reverb = new TalReverb((int)sampleRate);
 
-		dryParamChange = new ParamChangeUtil(sampleRate, 300.0f);
-		wetParamChange = new ParamChangeUtil(sampleRate, 300.0f);
+        dryParamChange = new ParamChangeUtil(sampleRate, 300.0f);
+        wetParamChange = new ParamChangeUtil(sampleRate, 300.0f);
 
-		noiseGenerator = new NoiseGenerator(sampleRate);
+        noiseGenerator = new NoiseGenerator(sampleRate);
 
-		dry = 1.0f;
-		wet = 0.5f;
-		stereoWidth = 1.0f;
-	}
+        dry = 1.0f;
+        wet = 0.5f;
+        stereoWidth = 1.0f;
+    }
 
-	void process(float *sampleL, float *sampleR) 
-	{
-		// avoid cpu spikes
-		float noise = noiseGenerator->tickNoise() * 0.000000001f;
+    void process(float *sampleL, float *sampleR) 
+    {
+        // avoid cpu spikes
+        float noise = noiseGenerator->tickNoise() * 0.000000001f;
 
-		*sampleL += noise;
-		*sampleR += noise;
+        *sampleL += noise;
+        *sampleR += noise;
 
-		float drysampleL = *sampleL;
-		float drysampleR = *sampleR;
+        float drysampleL = *sampleL;
+        float drysampleR = *sampleR;
 
-		reverb->process(sampleL, sampleR);
+        reverb->process(sampleL, sampleR);
 
-		// Process Stereo
-		float actualDryValue = dryParamChange->tick(dry);
-		float wet1 = wet * (stereoWidth * 0.5f + 0.5f);
-		float wet2 = wet * ((1.0f - stereoWidth) * 0.5f);
-		float resultL = *sampleL * wet1 + *sampleR * wet2 + drysampleL * actualDryValue;
-		float resultR = *sampleR * wet1 + *sampleL * wet2 + drysampleR * actualDryValue;
-		*sampleL = resultL;
-		*sampleR = resultR;
-	}
+        // Process Stereo
+        float actualDryValue = dryParamChange->tick(dry);
+        float wet1 = wet * (stereoWidth * 0.5f + 0.5f);
+        float wet2 = wet * ((1.0f - stereoWidth) * 0.5f);
+        float resultL = *sampleL * wet1 + *sampleR * wet2 + drysampleL * actualDryValue;
+        float resultR = *sampleR * wet1 + *sampleL * wet2 + drysampleR * actualDryValue;
+        *sampleL = resultL;
+        *sampleR = resultR;
+    }
 };
 #endif
 

--- a/ports/tal-reverb-2/source/Engine/ReverbEngine.h
+++ b/ports/tal-reverb-2/source/Engine/ReverbEngine.h
@@ -48,138 +48,138 @@ public:
 
 	AudioUtils audioUtils;
 
-    ReverbEngine(float sampleRate)
-    {
-        Params *params= new Params();
-        this->param= params->parameters;
-        initialize(sampleRate);
-    }
+	ReverbEngine(float sampleRate)
+	{
+		Params *params= new Params();
+		this->param= params->parameters;
+		initialize(sampleRate);
+	}
 
-    ~ReverbEngine()
-    {
-        delete reverb;
+	~ReverbEngine()
+	{
+		delete reverb;
 
-        delete noiseGenerator;
-    }
+		delete noiseGenerator;
+	}
 #ifdef __MOD_DEVICES__
-    void setDry(float dry)
-    {
+	void setDry(float dry)
+	{
         dry = (dry + 96.0) / (26.4 + 96.0);
-        this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
-    }
+		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
+	}
 
 	void setWet(float wet)
-    {
+	{
         wet = (wet + 96.0) / (26.4 + 96.0);
-        this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
-    }
+		this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
+	}
 #else
-    void setDry(float dry)
-    {
-        this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
-    }
+	void setDry(float dry)
+	{
+		this->dry = audioUtils.getLogScaledVolume(dry, 2.0f);
+	}
 
-    void setWet(float wet)
-    {
-        this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
-    }
+	void setWet(float wet)
+	{
+		this->wet = audioUtils.getLogScaledVolume(wet, 2.0f);
+	}
 #endif
-    void setDecayTime(float decayTime)
-    {
-        reverb->setDecayTime(decayTime);
-    }
+	void setDecayTime(float decayTime)
+	{
+		reverb->setDecayTime(decayTime);
+	}
 
-    void setPreDelay(float preDelay)
-    {
-        reverb->setPreDelay(preDelay);
-    }
+	void setPreDelay(float preDelay)
+	{
+		reverb->setPreDelay(preDelay);
+	}
 
-    void setLowShelfGain(float lowShelfGain)
-    {
-        reverb->setLowShelfGain(lowShelfGain);
-    }
+	void setLowShelfGain(float lowShelfGain)
+	{
+		reverb->setLowShelfGain(lowShelfGain);
+	}
 
-    void setHighShelfGain(float highShelfGain)
-    {
-        reverb->setHighShelfGain(highShelfGain);
-    }
+	void setHighShelfGain(float highShelfGain)
+	{
+		reverb->setHighShelfGain(highShelfGain);
+	}
 
-    void setLowShelfFrequency(float lowShelfFrequency)
-    {
-        reverb->setLowShelfFrequency(lowShelfFrequency);
-    }
+	void setLowShelfFrequency(float lowShelfFrequency)
+	{
+		reverb->setLowShelfFrequency(lowShelfFrequency);
+	}
 
-    void setHighShelfFrequency(float highShelfFrequency)
-    {
-        reverb->setHighShelfFrequency(highShelfFrequency);
-    }
+	void setHighShelfFrequency(float highShelfFrequency)
+	{
+		reverb->setHighShelfFrequency(highShelfFrequency);
+	}
 
-    void setPeakFrequency(float peakFrequency)
-    {
-        reverb->setPeakFrequency(peakFrequency);
-    }
+	void setPeakFrequency(float peakFrequency)
+	{
+		reverb->setPeakFrequency(peakFrequency);
+	}
 
-    void setPeakGain(float peakGain)
-    {
-        reverb->setPeakGain(peakGain);
-    }
+	void setPeakGain(float peakGain)
+	{
+		reverb->setPeakGain(peakGain);
+	}
 
-    void setStereoWidth(float stereoWidth)
-    {
-        this->stereoWidth = stereoWidth;
-    }
+	void setStereoWidth(float stereoWidth)
+	{
+		this->stereoWidth = stereoWidth;
+	}
 
-    void setStereoMode(float stereoMode)
-    {
-        reverb->setStereoMode(stereoMode > 0.0f ? true : false);
-    }
+	void setStereoMode(float stereoMode)
+	{
+		reverb->setStereoMode(stereoMode > 0.0f ? true : false);
+	}
 
-    void setSampleRate(float sampleRate)
-    {
-        initialize(sampleRate);
-    }
+	void setSampleRate(float sampleRate)
+	{
+		initialize(sampleRate);
+	}
 
-    void initialize(float sampleRate)
-    {
+	void initialize(float sampleRate)
+	{
         if (sampleRate <= 0)
         {
             sampleRate = 44100.0f;
         }
 
-        reverb = new TalReverb((int)sampleRate);
+		reverb = new TalReverb((int)sampleRate);
 
-        dryParamChange = new ParamChangeUtil(sampleRate, 300.0f);
-        wetParamChange = new ParamChangeUtil(sampleRate, 300.0f);
+		dryParamChange = new ParamChangeUtil(sampleRate, 300.0f);
+		wetParamChange = new ParamChangeUtil(sampleRate, 300.0f);
 
-        noiseGenerator = new NoiseGenerator(sampleRate);
+		noiseGenerator = new NoiseGenerator(sampleRate);
 
-        dry = 1.0f;
-        wet = 0.5f;
-        stereoWidth = 1.0f;
-    }
+		dry = 1.0f;
+		wet = 0.5f;
+		stereoWidth = 1.0f;
+	}
 
-    void process(float *sampleL, float *sampleR) 
-    {
-        // avoid cpu spikes
-        float noise = noiseGenerator->tickNoise() * 0.000000001f;
+	void process(float *sampleL, float *sampleR) 
+	{
+		// avoid cpu spikes
+		float noise = noiseGenerator->tickNoise() * 0.000000001f;
 
-        *sampleL += noise;
-        *sampleR += noise;
+		*sampleL += noise;
+		*sampleR += noise;
 
-        float drysampleL = *sampleL;
-        float drysampleR = *sampleR;
+		float drysampleL = *sampleL;
+		float drysampleR = *sampleR;
 
-        reverb->process(sampleL, sampleR);
+		reverb->process(sampleL, sampleR);
 
-        // Process Stereo
-        float actualDryValue = dryParamChange->tick(dry);
-        float wet1 = wet * (stereoWidth * 0.5f + 0.5f);
-        float wet2 = wet * ((1.0f - stereoWidth) * 0.5f);
-        float resultL = *sampleL * wet1 + *sampleR * wet2 + drysampleL * actualDryValue;
-        float resultR = *sampleR * wet1 + *sampleL * wet2 + drysampleR * actualDryValue;
-        *sampleL = resultL;
-        *sampleR = resultR;
-    }
+		// Process Stereo
+		float actualDryValue = dryParamChange->tick(dry);
+		float wet1 = wet * (stereoWidth * 0.5f + 0.5f);
+		float wet2 = wet * ((1.0f - stereoWidth) * 0.5f);
+		float resultL = *sampleL * wet1 + *sampleR * wet2 + drysampleL * actualDryValue;
+		float resultR = *sampleR * wet1 + *sampleL * wet2 + drysampleR * actualDryValue;
+		*sampleL = resultL;
+		*sampleR = resultR;
+	}
 };
 #endif
 

--- a/ports/tal-reverb-2/source/Engine/ReverbEngine.h
+++ b/ports/tal-reverb-2/source/Engine/ReverbEngine.h
@@ -25,8 +25,6 @@
 #if !defined(__ReverbEngine_h)
 #define __ReverbEngine_h
 
-#define __MOD_DEVICES__ 1
-
 #include "Reverb.h"
 #include "AudioUtils.h"
 #include "Params.h"

--- a/ports/tal-reverb-2/source/Engine/TalEq.h
+++ b/ports/tal-reverb-2/source/Engine/TalEq.h
@@ -57,6 +57,40 @@ public:
 	{
 	}
 
+#ifdef __MOD_DEVICES__
+	void setLowShelfGain(float lowShelfGain)
+	{
+        lowShelfGain = (lowShelfGain + 18.0 ) / 36.0;
+		this->lowShelfGain = lowShelfGain;
+	}
+
+	void setHighShelfGain(float highShelfGain)
+	{
+        highShelfGain = (highShelfGain + 18.0 ) / 36.0;
+		this->highShelfGain = highShelfGain;
+	}
+
+	void setPeakGain(float peakGain)
+	{
+        peakGain = (peakGain + 18.0 ) / 36.0;
+		this->peakGain = peakGain;
+	}
+
+	void setLowShelfFrequency(float lowShelfFrequency)
+	{
+		this->lowShelfFrequency = lowShelfFrequency;
+	}
+
+	void setHighShelfFrequency(float highShelfFrequency)
+	{
+		this->highShelfFrequency = highShelfFrequency;
+	}
+
+	void setPeakFrequency(float peakFrequency)
+	{
+		this->peakFrequency = peakFrequency;
+	}
+#else
 	void setLowShelfGain(float lowShelfGain)
 	{
 		this->lowShelfGain = lowShelfGain * 0.5f;
@@ -86,6 +120,7 @@ public:
 	{
 		this->peakFrequency = audioUtils.getLogScaledFrequency(peakFrequency);
 	}
+#endif
 
 	void initialize(float sampleRate)
 	{

--- a/ports/tal-reverb-2/source/Engine/TalEq.h
+++ b/ports/tal-reverb-2/source/Engine/TalEq.h
@@ -25,8 +25,6 @@
 #if !defined(__TalEq_h)
 #define __TalEq_h
 
-#define __MOD_DEVICES__ 1
-
 #include "HighShelf.h"
 #include "LowShelf.h"
 #include "PeakEq.h"

--- a/ports/tal-reverb-2/source/Engine/TalEq.h
+++ b/ports/tal-reverb-2/source/Engine/TalEq.h
@@ -25,6 +25,8 @@
 #if !defined(__TalEq_h)
 #define __TalEq_h
 
+#define __MOD_DEVICES__ 1
+
 #include "HighShelf.h"
 #include "LowShelf.h"
 #include "PeakEq.h"

--- a/ports/tal-reverb-2/source/JucePluginCharacteristics.h
+++ b/ports/tal-reverb-2/source/JucePluginCharacteristics.h
@@ -286,7 +286,13 @@
 
 #define JucePlugin_IsMidiEffect             0
 
-#define JucePlugin_LV2URI                   "urn:juce:TalReverb2"
+
+#if __MOD_DEVICES__
+  #define JucePlugin_LV2URI                 "http://moddevices.com/plugins/tal-reverb-2"
+#else
+  #define JucePlugin_LV2URI                 "urn:juce:TalReverb2"
+#endif
+
 #define JucePlugin_LV2Category              "ReverbPlugin"
 
 #define JucePlugin_WantsLV2Latency          0

--- a/ports/tal-reverb-2/source/TalCore.cpp
+++ b/ports/tal-reverb-2/source/TalCore.cpp
@@ -114,7 +114,7 @@ void TalCore::setParameter (int index, float newValue)
 				engine->setStereoWidth(newValue);
 				break;
 			case REALSTEREOMODE:
-				engine->setStereoMode((bool)newValue);
+				engine->setStereoMode(newValue);
 				break;
 			case LOWSHELFFREQUENCY:
 				engine->setLowShelfFrequency(newValue);
@@ -156,6 +156,9 @@ const String TalCore::getParameterName (int index)
 		case PEAKGAIN: return T("peak gain");
 		case STEREO: return T("stereo");
 		case REALSTEREOMODE: return T("stereo input");
+#ifndef __MOD_DEVICES__
+		case UNUSED: return "unused";
+#endif
 	}
     return String();
 }

--- a/ports/tal-reverb-2/source/TalCore.cpp
+++ b/ports/tal-reverb-2/source/TalCore.cpp
@@ -57,10 +57,12 @@ TalCore::TalCore()
 	for (int i = 0; i < NUMPROGRAMS; i++) talPresets[i] = new TalPreset();
 	curProgram = 0;
 
+#ifndef __MOD_DEVICES__
 	// load factory presets
 	ProgramChunk chunk;
 	setStateInformationString(chunk.getXmlChunk());
 	setCurrentProgram(curProgram);
+#endif
 }
 
 TalCore::~TalCore()
@@ -443,12 +445,15 @@ int TalCore::getCurrentProgram ()
 
 void TalCore::setCurrentProgram (int index)
 {
+
 	if (index < NUMPROGRAMS)
 	{
 		curProgram = index;
 		for (int i = 0; i < NUMPARAM; i++)
 		{
+#ifndef __MOD_DEVICES__
 			setParameter(i, talPresets[index]->programData[i]);
+#endif
 		}
 		sendChangeMessage ();
 	}

--- a/ports/tal-reverb-2/source/TalCore.cpp
+++ b/ports/tal-reverb-2/source/TalCore.cpp
@@ -146,19 +146,14 @@ const String TalCore::getParameterName (int index)
 		case DRY: return T("dry");
 		case DECAYTIME: return T("room size");
 		case PREDELAY: return T("pre delay");
-
 		case LOWSHELFFREQUENCY: return T("low shelf frequency");
 		case HIGHSHELFFREQUENCY: return T("high shelf frequency");
 		case PEAKFREQUENCY: return T("peak frequency");
-
 		case LOWSHELFGAIN: return T("low shelf gain");
 		case HIGHSHELFGAIN: return T("high shelf gain");
 		case PEAKGAIN: return T("peak gain");
-
 		case STEREO: return T("stereo");
 		case REALSTEREOMODE: return T("stereo input");
-
-		case UNUSED: return "unused";
 	}
     return String();
 }

--- a/ports/tal-reverb-2/source/TalCore.cpp
+++ b/ports/tal-reverb-2/source/TalCore.cpp
@@ -112,9 +112,8 @@ void TalCore::setParameter (int index, float newValue)
 				engine->setStereoWidth(newValue);
 				break;
 			case REALSTEREOMODE:
-				engine->setStereoMode(newValue);
+				engine->setStereoMode((bool)newValue);
 				break;
-
 			case LOWSHELFFREQUENCY:
 				engine->setLowShelfFrequency(newValue);
 				break;
@@ -124,7 +123,6 @@ void TalCore::setParameter (int index, float newValue)
 			case PEAKFREQUENCY:
 				engine->setPeakFrequency(newValue);
 				break;
-
 			case LOWSHELFGAIN:
 				engine->setLowShelfGain(newValue);
 				break;


### PR DESCRIPTION
Removed the use of normalized values for the parameters when plugin is compiled for MOD Devices.
The default settings of the parameters are already converted to not use normalization. The presets still need to be adjusted. 