### PR TITLE
Fixing an issue with running multiple custom build targets and meson.

### DIFF
--- a/ports/helper.sh
+++ b/ports/helper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+
+eval $@

--- a/ports/meson.build
+++ b/ports/meson.build
@@ -223,7 +223,7 @@ foreach plugin : plugins
                 output: plugin_name + '.lv2',
                 input: plugin_lv2_lib,
                 command: [
-                    'mkdir', '-p', plugin_lv2_dir, '&&',
+                    './helper.sh', 'mkdir', '-p', plugin_lv2_dir, '&&',
                     'cd', plugin_lv2_dir, '&&',
                     'mv', plugin_lv2_lib.full_path(), plugin_lv2_dir / plugin_name + lib_suffix, '&&',
                     (meson.is_cross_build() ? 'wine' : 'env'), lv2_ttl_generator, '.' / plugin_name + lib_suffix,
@@ -272,7 +272,7 @@ foreach plugin : plugins
                 output: plugin_name + '.vst3',
                 input: plugin_vst3_lib,
                 command: [
-                    'mkdir', '-p', plugin_vst3_dir, '&&',
+                    './helper.sh', 'mkdir', '-p', plugin_vst3_dir, '&&',
                     'cd', plugin_vst3_dir, '&&',
                     'mv', plugin_vst3_lib.full_path(), plugin_vst3_dir / plugin_name + lib_suffix,
                 ],


### PR DESCRIPTION
Hi.

I found an error when I attempted to compile one of the programs on windows.

As mentioned here (
https://mesonbuild.com/Custom-build-targets.html ), the Custom build targets in meson only allow you to run a single command.

So in the meson.build file in the ports subfolder, an error was occurring because of that.
`                command: [
                    'mkdir', '-p', plugin_lv2_dir, '&&',
                    'cd', plugin_lv2_dir, '&&',
                    'mv', plugin_lv2_lib.full_path(), plugin_lv2_dir / plugin_name + lib_suffix, '&&',
                    (meson.is_cross_build() ? 'wine' : 'env'), lv2_ttl_generator, '.' / plugin_name + lib_suffix,
                ],`
instead of running the mkdir commands, then the cd and mv commands. it would only run the mkdir command and try to make the files that mv was supposed to move. This caused the build script to exit prematurely.

To fix this I made a barebones helper script. Meson will now pass the desired commands as arguments to the script.
Then the script will run them. This fixed the compilation issue I had.