### PR TITLE
Vitalium: Revert key bind changes.

### DIFF
--- a/ports-juce6.0/vitalium/source/interface/editor_components/line_editor.cpp
+++ b/ports-juce6.0/vitalium/source/interface/editor_components/line_editor.cpp
@@ -385,7 +385,7 @@ void LineEditor::paintLine(const MouseEvent& e) {
   float from_x = (1.0f * active_grid_section_) / grid_size_x_;
   float to_x = (active_grid_section_ + 1.0f) / grid_size_x_;
 
-  if (!e.mods.isCtrlDown() && grid_size_y_ > 0) {
+  if (!e.mods.isAltDown() && grid_size_y_ > 0) {
     float snap_radius = getSnapRadiusY();
     float snapped_y = getSnappedY(percent_y);
     if (fabsf(snapped_y - percent_y) < snap_radius)
@@ -609,9 +609,9 @@ void LineEditor::drawDrag(const MouseEvent& e) {
     return;
 
   if (active_point_ >= 0)
-    movePoint(active_point_, e.position, !e.mods.isCtrlDown());
+    movePoint(active_point_, e.position, !e.mods.isAltDown());
   else if (active_power_ >= 0)
-    movePower(active_power_, e.position, e.mods.isShiftDown(), e.mods.isCtrlDown());
+    movePower(active_power_, e.position, e.mods.isShiftDown(), e.mods.isAltDown());
 
   resetPositions();
 }

--- a/ports-juce6.0/vitalium/source/interface/editor_components/synth_preset_selector.cpp
+++ b/ports-juce6.0/vitalium/source/interface/editor_components/synth_preset_selector.cpp
@@ -117,7 +117,7 @@ void SynthPresetSelector::resized() {
 
 void SynthPresetSelector::buttonClicked(Button* clicked_button) {
   if (clicked_button == menu_button_.get()) {
-    if (ModifierKeys::getCurrentModifiersRealtime().isCtrlDown())
+    if (ModifierKeys::getCurrentModifiersRealtime().isAltDown())
       showAlternatePopupMenu(menu_button_.get());
     else
       showPopupMenu(menu_button_.get());

--- a/ports-juce6.0/vitalium/source/interface/editor_components/synth_slider.cpp
+++ b/ports-juce6.0/vitalium/source/interface/editor_components/synth_slider.cpp
@@ -241,7 +241,7 @@ PopupItems SynthSlider::createPopupMenu() {
 void SynthSlider::mouseDown(const MouseEvent& e) {
   SynthBase* synth = synth_interface_->getSynth();
 
-  if (e.mods.isCtrlDown()) {
+  if (e.mods.isAltDown()) {
     showTextEntry();
     return;
   }
@@ -269,7 +269,7 @@ void SynthSlider::mouseDown(const MouseEvent& e) {
 }
 
 void SynthSlider::mouseDrag(const MouseEvent& e) {
-  if (e.mods.isCtrlDown())
+  if (e.mods.isAltDown())
     return;
   
   float multiply = 1.0f;
@@ -307,7 +307,7 @@ void SynthSlider::mouseDrag(const MouseEvent& e) {
 }
 
 void SynthSlider::mouseUp(const MouseEvent& e) {
-  if (e.mods.isPopupMenu() || e.mods.isCtrlDown())
+  if (e.mods.isPopupMenu() || e.mods.isAltDown())
     return;
 
   setDefaultRange();


### PR DESCRIPTION
Blindly rebinding these to Ctrl breaks several features including finetuning on knobs. Lets move these back to Alt for parity with the official release of Vital.

Closes #112.