### PR TITLE
Roth-Air fixes

### DIFF
--- a/ports-juce6.1/roth-air/DspFilters/Biquad.h
+++ b/ports-juce6.1/roth-air/DspFilters/Biquad.h
@@ -81,8 +81,10 @@ public:
   template <class StateType, typename Sample>
   void process (int numSamples, Sample* dest, StateType& state) const
   {
-    while (--numSamples >= 0)
-      *dest++ = state.process (*dest, *this);
+    while (--numSamples >= 0) {
+      *dest = state.process (*dest, *this);
+      dest++;
+    }
   }
 
 protected:
@@ -169,7 +171,8 @@ public:
       sectionPrev.m_b1 += db1;
       sectionPrev.m_b2 += db2;
 
-      *dest++ = state.process (*dest, sectionPrev);
+      *dest = state.process (*dest, sectionPrev);
+      dest++;
     }
   }
 
@@ -198,7 +201,8 @@ public:
       zPrev.zeros.second += dz1;
       zPrev.gain += dg;
 
-      *dest++ = state.process (*dest, Biquad (zPrev));
+      *dest = state.process (*dest, Biquad (zPrev));
+      dest++;
     }
   }
 

--- a/ports-juce6.1/roth-air/DspFilters/Cascade.h
+++ b/ports-juce6.1/roth-air/DspFilters/Cascade.h
@@ -120,8 +120,10 @@ public:
   template <class StateType, typename Sample>
   void process (int numSamples, Sample* dest, StateType& state) const
   {
-    while (--numSamples >= 0)
-      *dest++ = state.process (*dest, *this);
+    while (--numSamples >= 0) {
+      *dest = state.process (*dest, *this);
+      dest++;
+    }
   }
 
 protected:

--- a/ports-juce6.1/roth-air/DspFilters/Utilities.h
+++ b/ports-juce6.1/roth-air/DspFilters/Utilities.h
@@ -274,7 +274,8 @@ void fade (int samples,
 
   while (--samples >= 0)
   {
-    *dest++ = static_cast<Td>(*dest + t * (*src++ - *dest));
+    *dest = static_cast<Td>(*dest + t * (*src++ - *dest));
+    dest++;
     t += dt;
   }
 }
@@ -384,8 +385,10 @@ void multiply (int samples,
   }
   else
   {
-    while (--samples >= 0)
-      *dest++ = static_cast<Td>(*dest * factor);
+    while (--samples >= 0) {
+      *dest = static_cast<Td>(*dest * factor);
+      dest++;
+    }
   }
 }
 

--- a/ports-juce6.1/roth-air/DspFilters/Utilities.h
+++ b/ports-juce6.1/roth-air/DspFilters/Utilities.h
@@ -64,7 +64,7 @@ void add (int samples,
     ++destSkip;
     while (--samples >= 0)
     {
-      *dest = static_cast<Td>(*src);
+      *dest += static_cast<Td>(*src);
       dest += destSkip;
       src += srcSkip;
     }

--- a/ports-juce6.1/roth-air/DspFilters/Utilities.h
+++ b/ports-juce6.1/roth-air/DspFilters/Utilities.h
@@ -708,7 +708,7 @@ public:
       double e = m_env[i];
       for (int n = samples; n; n--)
       {
-        double v = ::fabs(*cur++);
+        double v = std::abs(*cur++);
         if (v > e)
           e = m_a * (e - v) + v;
         else

--- a/ports-juce6.1/roth-air/PluginEditor.h
+++ b/ports-juce6.1/roth-air/PluginEditor.h
@@ -148,7 +148,7 @@ private:
 
 	Image threshLabel = ImageCache::getFromMemory(BinaryData::label_thresh_png, BinaryData::label_thresh_pngSize);
 	Image freqLabel = ImageCache::getFromMemory(BinaryData::label_freq_png, BinaryData::label_freq_pngSize);
-	Image gainLabel = ImageCache::getFromMemory(BinaryData::label_gain_png, BinaryData::label_freq_pngSize);
+	Image gainLabel = ImageCache::getFromMemory(BinaryData::label_gain_png, BinaryData::label_gain_pngSize);
 	Image mixLabel = ImageCache::getFromMemory(BinaryData::label_mix_png, BinaryData::label_mix_pngSize);
 
 	Image redLight = ImageCache::getFromMemory(BinaryData::bigKnob_red_png, BinaryData::bigKnob_red_pngSize);

--- a/ports-juce6.1/roth-air/PluginProcessor.cpp
+++ b/ports-juce6.1/roth-air/PluginProcessor.cpp
@@ -214,9 +214,11 @@ void AirAudioProcessor::processBlock (AudioSampleBuffer& buffer, MidiBuffer& mid
     }
 
 	// Set filter crossover param every block
-	filterParams[2] = *crossFreq; // Set center freq
-	lp->setParams(filterParams);
-	hp->setParams(filterParams);
+	if (filterParams[2] != *crossFreq) {
+		filterParams[2] = *crossFreq; // Set center freq
+		lp->setParams(filterParams);
+		hp->setParams(filterParams);
+	}
 
 	// Apply the filters to respective buffers
 	hp->process(numSamples, hpBuffer.getArrayOfWritePointers());

--- a/ports-juce6.1/roth-air/meson.build
+++ b/ports-juce6.1/roth-air/meson.build
@@ -18,4 +18,7 @@ plugin_srcs = files([
 
 plugin_name = 'Roth-Air'
 
+# DSP code uses direct comparison with infinity
+plugin_extra_build_flags = '-fno-finite-math-only'
+
 ###############################################################################


### PR DESCRIPTION
This PR puts together a few fixes that made Roth-Air, built as LV2 plugin with GCC14, work on my machine (x86_64 linux, ardour 8.12 as a host):

* DspFilters bugfixes, backported from their current upstream;
* typo/copypaste fix for GAIN label image loading;
* disable GCC's `finit-math-only` optimization to make highpass and lopass filters actually work, instead of producing just a stream of NaNs.