### PR TITLE
drowaudio-reverb: Fix working on higher sample rates

### DIFF
--- a/ports-juce5/drowaudio-common/dRowAudio_TappedDelayLine.h
+++ b/ports-juce5/drowaudio-common/dRowAudio_TappedDelayLine.h
@@ -32,9 +32,9 @@ class TappedDelayLine
 {
 public:
 	/** Creates a TappedDelayline with a given size in samples.
-		If no size is specified a default of 9600 is used.
+		If no size is specified a default of 640000 is used.
 	 */
-	TappedDelayLine(int initialBufferSize =96000);
+	TappedDelayLine(int initialBufferSize=640000);
 	TappedDelayLine(float bufferLengthMs, double sampleRate);
 	
 	/// Destructor


### PR DESCRIPTION
The tap delay buffer should be able to hold a few seconds of audio. When it does not, it leads to out-of-bounds reads, which may lead to segfaults or other glitches.

Following the infamous "640k ought to be enough for anybody" motto, we increase the default tap delay buffer size to make it large enough for any reasonable sample rate. This increases RAM usage of the plugin by ~1Mb, which seems reasonable by modern day standards.