### PR TITLE
generate-lv2.sh: Loongarch64 support

### DIFF
--- a/scripts/generate-lv2.sh
+++ b/scripts/generate-lv2.sh
@@ -34,6 +34,11 @@ if [ -z "${MESON_EXE_WRAPPER}" ]; then
             MESON_EXE_WRAPPER="qemu-i386-static"
         fi
 
+    elif echo "${fileout}" | grep -q "LoongArch"; then
+        if [ "$(uname -m)" != "loongarch64" ]; then
+            MESON_EXE_WRAPPER="qemu-loongarch64-static"
+        fi
+
     elif echo "${fileout}" | grep -q "RISC-V"; then
         if [ "$(uname -m)" != "riscv64" ]; then
             MESON_EXE_WRAPPER="qemu-riscv64-static"


### PR DESCRIPTION
With this, I can build most of the plugins as LV2 on my LoongArch64 machine.